### PR TITLE
Update 22_field_api.md

### DIFF
--- a/docs/22_field_api.md
+++ b/docs/22_field_api.md
@@ -1,6 +1,6 @@
 ## `chz.field`
 
-`chz.field takes the following parameters:
+`chz.field` takes the following parameters:
 
 #### `default`
 


### PR DESCRIPTION
This pull request includes a minor documentation fix in the `docs/22_field_api.md` file. The change corrects a formatting error in the `chz.field` function description.

* [`docs/22_field_api.md`](diffhunk://#diff-3ea3c37d06fb4b05607a8f317420a312536903132a067b81cd181d44a5cac261L3-R3): Corrected the formatting of the `chz.field` function description by adding a backtick to properly enclose the function name.

## Summary by Sourcery

Documentation:
- Corrected markdown formatting by adding a backtick to properly enclose the `chz.field` function name in the documentation